### PR TITLE
docs: Add fork attribution to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An MCP (Model Context Protocol) server that provides web search capabilities using OpenAI models. The `o4-search` tool accepts text queries and returns AI-powered search results with advanced reasoning capabilities.
 
+> Note: This repository is a fork of [yoshiko-pg/o3-search-mcp](https://github.com/yoshiko-pg/o3-search-mcp).
+
 ## Supported Models
 
 - `o4-mini` (default)


### PR DESCRIPTION
## Summary
Add a clear fork attribution to the README linking to the original repository.

## Changes
- Add a “Fork” note in README with a link to yoshiko-pg/o3-search-mcp

## Why
To credit the original project and clarify the origin of this fork for new contributors and users.

## Notes
- No functional changes; documentation-only update.

## Testing
- Render README on GitHub to ensure the link displays correctly.
- Confirm no unintended formatting regressions in README preview.
