### PR TITLE
Add LICENSE file from upstream repository

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 @yoshiko-pg/o3-search-mcp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2025 @yoshiko-pg/o3-search-mcp
+Portions Copyright (c) 2025 @mkusaka
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Add MIT LICENSE file from the upstream repository [@yoshiko-pg/o3-search-mcp](https://github.com/yoshiko-pg/o3-search-mcp)
- Include fork attribution as suggested by the upstream author

## Context
The upstream repository recently added proper licensing in commit [1ad6938](https://github.com/yoshiko-pg/o3-search-mcp/commit/1ad6938fcfe504246feef32c153e840436f0496c). This PR follows that change and adds the LICENSE file to our fork with appropriate attribution.

## Changes
- Added LICENSE file with original copyright notice
- Added "Portions Copyright" attribution for fork modifications

## Test plan
- [x] Verified LICENSE file matches upstream format
- [x] Confirmed appropriate attribution is included