### PR TITLE
chore: remove unused minimist dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,10 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.13.2",
-    "minimist": "^1.2.8",
     "openai": "^5.8.1",
     "zod": "^3.25.67"
   },
   "devDependencies": {
-    "@types/minimist": "^1.2.5",
     "@types/node": "^24.0.4",
     "typescript": "^5.8.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.13.2
         version: 1.13.2
-      minimist:
-        specifier: ^1.2.8
-        version: 1.2.8
       openai:
         specifier: ^5.8.1
         version: 5.8.1(zod@3.25.67)
@@ -21,9 +18,6 @@ importers:
         specifier: ^3.25.67
         version: 3.25.67
     devDependencies:
-      '@types/minimist':
-        specifier: ^1.2.5
-        version: 1.2.5
       '@types/node':
         specifier: ^24.0.4
         version: 24.0.4
@@ -36,9 +30,6 @@ packages:
   '@modelcontextprotocol/sdk@1.13.2':
     resolution: {integrity: sha512-Vx7qOcmoKkR3qhaQ9qf3GxiVKCEu+zfJddHv6x3dY/9P6+uIwJnmuAur5aB+4FDXf41rRrDnOEGkviX5oYZ67w==}
     engines: {node: '>=18'}
-
-  '@types/minimist@1.2.5':
-    resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
   '@types/node@24.0.4':
     resolution: {integrity: sha512-ulyqAkrhnuNq9pB76DRBTkcS6YsmDALy6Ua63V8OhrOBgbcYt6IOdzpw5P1+dyRIyMerzLkeYWBeOXPpA9GMAA==}
@@ -236,9 +227,6 @@ packages:
     resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
 
-  minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -422,8 +410,6 @@ snapshots:
       zod-to-json-schema: 3.24.6(zod@3.25.67)
     transitivePeerDependencies:
       - supports-color
-
-  '@types/minimist@1.2.5': {}
 
   '@types/node@24.0.4':
     dependencies:
@@ -638,8 +624,6 @@ snapshots:
   mime-types@3.0.1:
     dependencies:
       mime-db: 1.54.0
-
-  minimist@1.2.8: {}
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
## Summary
- Remove unused `minimist` and `@types/minimist` packages from dependencies

## Why
These packages are not being used anywhere in the codebase:
- No imports of `minimist` found in any TypeScript files
- The project doesn't use command-line argument parsing

## Changes
- Removed `minimist` from dependencies
- Removed `@types/minimist` from devDependencies
- Updated `pnpm-lock.yaml` accordingly

## Test plan
- [x] Build still works: `pnpm build`
- [x] No TypeScript errors
- [x] MCP server still runs correctly