### PR TITLE
chore: use packageManager as pnpm source of truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v3
-        with:
-          version: 10.10.0
 
       - uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "description": "MCP server for web search using OpenAI models (o4-mini, gpt-5, etc.)",
   "type": "module",
-  "packageManager": "pnpm@10.10.0",
+  "packageManager": "pnpm@10.32.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Summary

Raise pnpm to 10.32.1 and use `package.json` as the single source of truth for the pnpm version.

Changes
- update `package.json` `packageManager` from `pnpm@10.10.0` to `pnpm@10.32.1`
- remove the redundant `with.version` pin from `.github/workflows/ci.yml`
- keep the CI workflow relying on `pnpm/action-setup` plus the checked-in `packageManager` declaration

Why

The repository was managing the pnpm version in both `package.json` and the CI workflow. Keeping the version in one place makes future pnpm upgrades simpler and avoids drift between local and CI environments.

Notes

This change does not alter the project build or lint commands. It only updates the declared pnpm version and removes the duplicated workflow pin.

Testing

- `node -e "console.log(require('./package.json').packageManager)"`
- `actionlint`
- `pnpm install --frozen-lockfile`
- `pnpm run check`
